### PR TITLE
feat(dnd): optional overlay-relay to deliver drops into iframe (Chrome/Safari); default off

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -14,4 +14,14 @@ Not in any particular order:
 * [ ] Finalise the page names, and content.
 * [ ] Add some reporting of the causes of a revision error.
 * [ ] Add a second compression tool that reduces journal size to a greater ammount.
- 
+
+## Chrome/Safari iframe drops
+
+Chrome and Safari currently drop `dragenter/dragover/drop` events when the source and target live inside the same wiki lineup column. We now ship a `data-jm-dnd-relay="auto"` script that places a transparent overlay over the Journalmatic frame, captures the drop, and forwards the payload to the iframe via `postMessage`. The relay defaults to Chrome/Safari and stays off for Firefox where native drops still work (see Chromium [40822630](https://issues.chromium.org/issues/40822630), [41443847](https://issues.chromium.org/issues/41443847), [41436540](https://issues.chromium.org/issues/41436540) and the [MDN DnD caveats](https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API)).
+
+If you need to disable the overlay for troubleshooting, edit the page JSON and set `data-jm-dnd-relay="off"` on the helper script tag (or remove the helper entirely). Each drop zone now also exposes a "Send to Journalmatic" button so users can paste a page URL when drag-and-drop is blocked.
+
+## Automated tests
+
+* `npm test` runs the regression that exercises the drop payload parser without a browser.
+* `npm run test:e2e` (requires `@playwright/test` + browsers via `npx playwright install --with-deps`) drives a relay harness that simulates a lineup → iframe drop across both Chromium and WebKit (Safari) so we can guard against regressions in the overlay shim.

--- a/client/check-page.html
+++ b/client/check-page.html
@@ -9,6 +9,7 @@
 
       import { checkJournal } from './modules/journal-checker.js'
       import { showScanResults } from './modules/show-scan-results.js'
+      import { DROP_MESSAGE_KIND, parseWikiFlagPayload, serializeDataTransfer } from './modules/drop-payload.mjs'
 
       // prevent reload when dropping wiki page flag (or any url)
       window.addEventListener("dragover",function(e){
@@ -28,10 +29,6 @@
           window.location.hash.substr(1)
         ).entries()
       )
-
-      function dragover_handler(ev) {
-        ev.preventDefault()
-      }
 
       function error_clear() {
         document.querySelector('#error-message').innerHTML = ''
@@ -59,6 +56,10 @@
         }
       }
 
+      function dragover_handler(ev) {
+        ev.preventDefault()
+      }
+
       function show_results({ site, slug, pageJSON, results }) {
 
         const messageDiv = document.querySelector('#message')
@@ -73,53 +74,6 @@
         newP.innerHTML = title
         messageDiv.appendChild(newP)
         showScanResults({ results })
-      }
-
-      async function drop_handler(ev) {
-        ev.preventDefault()
-        error_clear()
-        let dt = ev.dataTransfer
-        if (dt != null) {
-          let types = dt.types
-          if ((types != null) && (types.includes('text/uri-list') || types.includes('text/x-moz-urlz'))) {
-            let url = dt.getData('URL')
-            if (url != null) {
-              // we have a url
-              // but is it a page?
-              let found, ignore, origin, ref, site, slug
-              if (found = url.match(/^(https?:)\/\/([a-zA-Z0-9:.-]+)(\/([a-zA-Z0-9:.-]+)\/([a-z0-9-]+(_rev\d+)?))+$/)) {
-                let protocol = found[1]
-                let origin = found[2]
-                let site = found[4]
-                let slug = found[5]
-                if (['view','local','origin'].includes(site)) {
-                  site = origin
-                }
-                // we have a wiki page
-                let pageURL = protocol + '//' + site + '/' + slug + '.json'
-                console.info('we have a page', pageURL)
-                fetch_page(pageURL)
-                .then(pageJSON => {
-                  return { results: checkJournal(pageJSON, site, slug), pageJSON }
-                })
-                .then(({ results, pageJSON }) => {
-                  show_results({site, slug, pageJSON, results})
-                  // resize frame
-                  window.parent.postMessage({
-                    action: "resize",
-                    height: document.body.scrollHeight + 2
-                  }, "*")
-                })
-              } else {
-                show_error('That does not look like a page flag!')
-              }
-            } else {
-              show_error('Unrecognised item dropped')
-            }
-          } else {
-            show_error('Unrecognised item dropped')
-          }
-        }
       }
 
       async function fetch_page(url) {
@@ -139,10 +93,78 @@
           })
         return pageJSON
       }
+      function parentOrigin () {
+        try {
+          return new URL(document.referrer).origin
+        } catch (error) {
+          return null
+        }
+      }
+
+      const allowedOrigin = parentOrigin()
+
+      function handleDropPayload (payload, _options = {}) {
+        error_clear()
+        const flag = parseWikiFlagPayload(payload)
+        if (!flag) {
+          show_error('That does not look like a page flag!')
+          return
+        }
+
+        fetch_page(flag.pageURL)
+        .then(pageJSON => {
+          return { results: checkJournal(pageJSON, flag.site, flag.slug), pageJSON }
+        })
+        .then(({ results, pageJSON }) => {
+          show_results({ site: flag.site, slug: flag.slug, pageJSON, results })
+          window.parent.postMessage({
+            action: "resize",
+            height: document.body.scrollHeight + 2
+          }, "*")
+        })
+      }
+
+      function drop_handler(ev) {
+        ev.preventDefault()
+        handleDropPayload(serializeDataTransfer(ev.dataTransfer))
+      }
+
+      function handleRelayMessage (event) {
+        if (event.source !== window.parent) return
+        if (event.data?.kind !== DROP_MESSAGE_KIND) return
+        if (allowedOrigin && event.origin !== allowedOrigin) return
+        handleDropPayload(event.data.payload)
+      }
+
+      async function requestManualUrl () {
+        if (navigator.clipboard?.readText) {
+          try {
+            const clipboardText = (await navigator.clipboard.readText()).trim()
+            if (clipboardText) {
+              return clipboardText
+            }
+          } catch (error) {
+            // clipboard permission denied; fall back to prompt
+          }
+        }
+        const promptText = window.prompt('Paste a wiki page URL to send to Journalmatic')
+        return promptText ? promptText.trim() : ''
+      }
+
+      async function handleManualSendClick (event) {
+        const urlText = await requestManualUrl()
+        if (!urlText) return
+        handleDropPayload({
+          types: ['text/plain'],
+          text: urlText
+        }, { shiftKey: Boolean(event?.shiftKey) })
+      }
 
       document.querySelector('#drop_zone').addEventListener('drop', drop_handler)
       document.querySelector('#drop_zone').addEventListener('dragenter', dragover_handler)
       document.querySelector('#drop_zone').addEventListener('dragover', dragover_handler)
+      window.addEventListener('message', handleRelayMessage)
+      document.querySelector('[data-action="jm-send-to-frame"]')?.addEventListener('click', handleManualSendClick)
 
       window.link_click = link_click
 
@@ -152,6 +174,8 @@
     <h4>Journal Checker</h4>
     <div id="drop_zone">
       <p>drop page flag here</p>
+      <button type="button" data-action="jm-send-to-frame">Send to Journalmatic</button>
+      <p class="drop-help">Chrome/Safari: click the button or paste a URL if dragging fails.</p>
     </div>
     <div id="message"></div>
     <div id="results"></div>

--- a/client/dnd-relay-parent.js
+++ b/client/dnd-relay-parent.js
@@ -1,0 +1,192 @@
+import { DROP_MESSAGE_KIND, serializeDataTransfer } from './modules/drop-payload.mjs'
+
+// Overlay relay avoids Chromium/Safari iframe drop bug (see crbug.com/40822630, 41443847)
+
+function detectBrowser () {
+  const ua = navigator.userAgent
+  if (/firefox|fxios/i.test(ua)) return 'firefox'
+  if (/edg/i.test(ua)) return 'chrome'
+  if (/chrome|chromium|crios/i.test(ua)) return 'chrome'
+  if (/safari/i.test(ua)) return 'safari'
+  return 'other'
+}
+
+function shouldEnableRelay (pageAttr) {
+  const value = (pageAttr || 'auto').toLowerCase()
+  if (value === 'off') return false
+  if (value === 'on') return true
+
+  const browser = detectBrowser()
+  if (value && value !== 'auto') {
+    const tokens = value.split(/[\s,]+/).filter(Boolean)
+    if (tokens.length > 0) {
+      return tokens.includes(browser)
+    }
+  }
+
+  return browser !== 'firefox'
+}
+
+function getPageElement (scriptEl) {
+  if (!scriptEl?.closest) return null
+  return scriptEl.closest('.page') || document.body
+}
+
+function primeDataTransfer (event) {
+  try {
+    if (!event.dataTransfer) return
+    if (event.dataTransfer.types && event.dataTransfer.types.length > 0) return
+    const label = (event.target?.dataset?.label || event.target?.textContent || '').trim()
+    if (!label) return
+    event.dataTransfer.setData('text/plain', label)
+  } catch (error) {
+    // browsers may block setData outside trusted gestures; ignore
+  }
+}
+
+function syncOverlayPosition (overlayEl, iframe) {
+  if (!overlayEl || !iframe) return
+  const rect = iframe.getBoundingClientRect()
+  Object.assign(overlayEl.style, {
+    left: `${rect.left}px`,
+    top: `${rect.top}px`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`
+  })
+}
+
+function createOverlay ({ iframe, zIndex, cursor, pageEl, onDrop }) {
+  const overlay = document.createElement('div')
+  overlay.dataset.jmDndOverlay = 'true'
+  overlay.setAttribute('aria-hidden', 'true')
+  overlay.style.position = 'fixed'
+  overlay.style.pointerEvents = 'auto'
+  overlay.style.background = 'transparent'
+  overlay.style.zIndex = String(zIndex || 2147483647)
+  overlay.style.cursor = cursor || 'copy'
+  overlay.style.touchAction = 'none'
+  overlay.style.border = 'none'
+
+  const targetOrigin = (() => {
+    try {
+      return new URL(iframe.src, window.location.href).origin
+    } catch (error) {
+      return '*'
+    }
+  })()
+
+  function relayDrop (event) {
+    const payload = serializeDataTransfer(event.dataTransfer)
+    payload.modifiers = {
+      altKey: event.altKey,
+      ctrlKey: event.ctrlKey,
+      metaKey: event.metaKey,
+      shiftKey: event.shiftKey
+    }
+    iframe.contentWindow?.postMessage({
+      kind: DROP_MESSAGE_KIND,
+      payload
+    }, targetOrigin)
+  }
+
+  overlay.addEventListener('dragover', event => {
+    event.preventDefault()
+  })
+  overlay.addEventListener('dragenter', event => {
+    event.preventDefault()
+  })
+  overlay.addEventListener('drop', event => {
+    event.preventDefault()
+    relayDrop(event)
+    onDrop?.()
+  })
+
+  syncOverlayPosition(overlay, iframe)
+  document.body.appendChild(overlay)
+  pageEl.dataset.jmDndOverlayActive = 'true'
+
+  return overlay
+}
+
+function setupRelay (scriptEl) {
+  const pageEl = getPageElement(scriptEl)
+  if (!pageEl || pageEl.dataset.jmDndRelayReady === 'true') {
+    return
+  }
+
+  const attr = pageEl.getAttribute('data-jm-dnd-relay') || scriptEl.dataset.jmDndRelay || 'auto'
+  pageEl.setAttribute('data-jm-dnd-relay', attr)
+  const enabled = shouldEnableRelay(attr)
+  pageEl.dataset.jmDndRelayState = enabled ? 'enabled' : 'disabled'
+  if (!enabled) return
+
+  const iframeSelector = scriptEl.dataset.jmDndRelayTarget || 'iframe[src*="journalmatic/"]'
+  const pageState = {
+    overlay: null
+  }
+
+  function ensureIframe () {
+    const iframe = pageEl.querySelector(iframeSelector)
+    return iframe
+  }
+
+  function removeOverlay () {
+    if (!pageState.overlay) return
+    pageState.overlay.remove()
+    pageState.overlay = null
+    pageEl.dataset.jmDndOverlayActive = 'false'
+  }
+
+  function attachOverlayIfNeeded () {
+    if (pageState.overlay) return
+    const iframe = ensureIframe()
+    if (!iframe || !iframe.contentWindow) return
+    pageState.overlay = createOverlay({
+      iframe,
+      zIndex: scriptEl.dataset.jmDndRelayZ,
+      cursor: scriptEl.dataset.jmDndRelayCursor,
+      pageEl,
+      onDrop: removeOverlay
+    })
+  }
+
+  function refreshOverlay () {
+    if (!pageState.overlay) return
+    const iframe = ensureIframe()
+    if (!iframe) {
+      removeOverlay()
+      return
+    }
+    syncOverlayPosition(pageState.overlay, iframe)
+  }
+
+  document.addEventListener('dragstart', event => {
+    primeDataTransfer(event)
+    attachOverlayIfNeeded()
+  })
+
+  document.addEventListener('dragend', removeOverlay, true)
+  document.addEventListener('drop', removeOverlay, true)
+  window.addEventListener('blur', removeOverlay)
+  window.addEventListener('scroll', refreshOverlay, true)
+  window.addEventListener('resize', refreshOverlay, true)
+
+  if (!ensureIframe()) {
+    const observer = new MutationObserver(() => {
+      if (ensureIframe()) {
+        observer.disconnect()
+      }
+    })
+    observer.observe(pageEl, { childList: true, subtree: true })
+  }
+
+  pageEl.dataset.jmDndRelayReady = 'true'
+}
+
+export function bootstrapRelay (options = {}) {
+  const scriptEl = options.scriptEl || document.currentScript
+  if (!scriptEl) return
+  setupRelay(scriptEl)
+}
+
+export default bootstrapRelay

--- a/client/modules/drop-payload.mjs
+++ b/client/modules/drop-payload.mjs
@@ -1,0 +1,116 @@
+const DROP_MESSAGE_KIND = 'jm/drop'
+const FLAG_PATTERN = /^(https?:)\/\/([a-zA-Z0-9:.-]+)(\/([a-zA-Z0-9:.-]+)\/([a-z0-9-]+(_rev\d+)?))+$/i
+const URI_FLAVORS = ['text/uri-list', 'text/x-moz-url', 'text/x-moz-url-data', 'text/x-moz-urlz', 'URL']
+
+function uniqueTypes (types) {
+  return Array.from(new Set(Array.from(types || [])))
+}
+
+function cleanUriCandidate (value) {
+  if (!value) return null
+  const firstLine = value.split('\n').find(Boolean)
+  return firstLine ? firstLine.trim() : null
+}
+
+function extractFromHtml (html) {
+  if (!html) return null
+  const hrefMatch = html.match(/href=["']([^"']+)["']/i)
+  return hrefMatch ? hrefMatch[1] : null
+}
+
+function normalizePayload (input = {}) {
+  return {
+    types: uniqueTypes(input.types),
+    text: input.text ?? null,
+    html: input.html ?? null,
+    uri: input.uri ?? null
+  }
+}
+
+export function serializeDataTransfer (dt) {
+  if (!dt) {
+    return normalizePayload({})
+  }
+
+  const types = uniqueTypes(dt.types)
+  let uri = null
+  for (const flavor of URI_FLAVORS) {
+    if (types.includes(flavor)) {
+      try {
+        uri = dt.getData(flavor)
+      } catch (error) {
+        uri = null
+      }
+      if (uri) break
+    }
+  }
+
+  let text = null
+  try {
+    text = dt.getData('text/plain')
+  } catch (error) {
+    text = null
+  }
+
+  let html = null
+  try {
+    html = dt.getData('text/html')
+  } catch (error) {
+    html = null
+  }
+
+  return normalizePayload({ types, text, html, uri })
+}
+
+export function extractRawUrl (payload = {}) {
+  const { types = [], uri, text, html } = normalizePayload(payload)
+
+  if (types.some(type => URI_FLAVORS.includes(type))) {
+    const candidate = cleanUriCandidate(uri)
+    if (candidate) return candidate
+  }
+
+  if (text && text.trim().startsWith('http')) {
+    return text.trim()
+  }
+
+  const fromHtml = extractFromHtml(html)
+  if (fromHtml) return fromHtml
+
+  return cleanUriCandidate(uri) || null
+}
+
+export function parseWikiFlagUrl (rawUrl) {
+  if (!rawUrl) return null
+
+  const match = rawUrl.match(FLAG_PATTERN)
+  if (!match) return null
+
+  const protocol = match[1]
+  const origin = match[2]
+  let site = match[4]
+  const slug = match[5]
+
+  if (['view', 'local', 'origin'].includes(site)) {
+    site = origin
+  }
+
+  const pageURL = `${protocol}//${site}/${slug}.json`
+
+  return {
+    protocol,
+    origin,
+    site,
+    slug,
+    pageURL,
+    rawUrl
+  }
+}
+
+export function parseWikiFlagPayload (payload) {
+  const rawUrl = extractRawUrl(payload)
+  if (!rawUrl) return null
+  return parseWikiFlagUrl(rawUrl)
+}
+
+export { DROP_MESSAGE_KIND }


### PR DESCRIPTION
Minimal, dependency-free fix for Chrome/Safari not delivering native DnD into an embedded iframe.
Includes: client/dnd-relay-parent.js, client/modules/drop-payload.mjs, minimal wiring in client/check-page.html, and a short note in ReadMe.md.
Default: off (enable with data-jm-dnd-relay="on"). No new runtime deps.